### PR TITLE
Find libxml headers.

### DIFF
--- a/pkgs/applications/editors/xmlcopyeditor/default.nix
+++ b/pkgs/applications/editors/xmlcopyeditor/default.nix
@@ -12,13 +12,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ aspell boost expat expect intltool libxml libxslt pcre xercesc wxwidgets ];
 
-  CFLAGS="-I${pkgs.libxml2.dev}/include/libxml2/libxml";
-  CPPFLAGS="-I${pkgs.libxml2.dev}/include/libxml2/libxml";
-
-  preConfigure = ''
-    export CFLAGS="-I${pkgs.libxml2.dev}/include/libxml2/libxml"
-    export CPPFLAGS="-I${pkgs.libxml2.dev}/include/libxml2/libxml"
-  '';
+  C_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
+  CPLUS_INCLUDE_PATH = "${pkgs.libxml2.dev}/include/libxml2";
 
   meta = {
     description = "A fast, free, validating XML editor";


### PR DESCRIPTION
###### Motivation for this change

Make build progress further.

###### Things done

Made build process find libxml headers.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

